### PR TITLE
登録語一覧ページの編集

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,1 +1,12 @@
 @import "bootstrap";
+
+.word_box {
+  color: #666;
+  background: #f6f6f6;
+  text-align: left;
+  border-left: solid 7px #FFC107;
+  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  padding: 1em;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def after_sign_in_path_for(resource)
+    words_path
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -1,0 +1,4 @@
+class WordsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -1,4 +1,5 @@
 class WordsController < ApplicationController
   def index
+    @user = current_user
   end
 end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -1,5 +1,6 @@
 class WordsController < ApplicationController
   def index
     @user = current_user
+    @words = @user.words.page(params[:page]).per(24)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  has_many :words, dependent: :destroy
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   validates :name, presence: true

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -1,0 +1,3 @@
+class Word < ApplicationRecord
+  belongs_to :user
+end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,7 +22,7 @@
           <!-- ドロップメニューの設定 -->
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
             <%= link_to 'マイページ', '#', class: 'nav-link dropdown-item' %>
-            <%= link_to 'アカウント設定', '#', class: 'nav-link dropdown-item' %>
+            <%= link_to 'アカウント設定', edit_user_registration_path, class: 'nav-link dropdown-item' %>
           <div class="dropdown-divider"></div>
             <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link dropdown-item' %>
           </div><!-- /.dropdown-menu -->

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Words#index</h1>
+<p>Find me in app/views/words/index.html.erb</p>

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -15,8 +15,8 @@
     <div class="container mt-5">
       <div class="row">
         <!-- 登録内容繰り返し表示 -->
-        <% @user.words.each do |word| %>
-          <div class="p-2 col-md-4">
+        <% @words.each do |word| %>
+          <div class="p-2 col-lg-4">
             <div class="word_box">
               <%= word.word %>
             </div>
@@ -25,5 +25,9 @@
       </div>
     </div>
 
+    <!-- ページネーション -->
+    <div class="row justify-content-center mt-4">
+      <%= paginate @words %>
+    </div>
   </div>
 </div>

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -14,15 +14,14 @@
     <!-- 登録語表示エリア -->
     <div class="container mt-5">
       <div class="row">
-        <div class="word_box col-md pl-3 m-2">
-          Ruby
-        </div>
-        <div class="word_box col-md pl-3 m-2">
-         Ruby on Rails
-        </div>
-        <div class="word_box col-md pl-3 m-2">
-          Strong Parameters
-        </div>
+        <!-- 登録内容繰り返し表示 -->
+        <% @user.words.each do |word| %>
+          <div class="p-2 col-md-4">
+            <div class="word_box">
+              <%= word.word %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -1,2 +1,30 @@
-<h1>Words#index</h1>
-<p>Find me in app/views/words/index.html.erb</p>
+<% provide :title, 'マイページ' %>
+
+<div class="row justify-content-md-center">
+  <div class="col-md-10 coffset-md-1">
+
+    <!-- 検索フォーム -->
+    <div class="input-group mb-3">
+      <input type="text" class="form-control" placeholder="search..." aria-label="search" aria-describedby="basic-addon2">
+      <div class="input-group-append">
+        <span class="input-group-text" id="basic-addon2"><%= fa_icon 'search' %></span>
+      </div>
+    </div>
+
+    <!-- 登録語表示エリア -->
+    <div class="container mt-5">
+      <div class="row">
+        <div class="word_box col-md pl-3 m-2">
+          Ruby
+        </div>
+        <div class="word_box col-md pl-3 m-2">
+         Ruby on Rails
+        </div>
+        <div class="word_box col-md pl-3 m-2">
+          Strong Parameters
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :words
   devise_for :users
   root :to => 'static_pages#home'
 end

--- a/db/migrate/20180520003851_create_words.rb
+++ b/db/migrate/20180520003851_create_words.rb
@@ -1,0 +1,13 @@
+class CreateWords < ActiveRecord::Migration[5.2]
+  def change
+    create_table :words do |t|
+      t.integer :user_id
+      t.string :word
+      t.string :kana
+      t.text :content
+      t.text :content_replace
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_13_132238) do
+ActiveRecord::Schema.define(version: 2018_05_20_003851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,16 @@ ActiveRecord::Schema.define(version: 2018_05_13_132238) do
     t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "words", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "word"
+    t.string "kana"
+    t.text "content"
+    t.text "content_replace"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end


### PR DESCRIPTION
# WHAT

- ログイン後の画面である登録語一覧ページを編集
    - 検索ボックスの設置
    - ユーザーが登録した言葉を取得して一覧で表示
    - ページネーションを使って24件ずつ表示するように調整

<img width="801" alt="chobimemo014" src="https://user-images.githubusercontent.com/38174128/40276310-b620ef52-5c41-11e8-8662-45f0bf5a58a5.png">