### PR TITLE
単語登録機能の操作をログインユーザーにのみ許可

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
   def home
+    redirect_to words_path if user_signed_in?
   end
 end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -1,4 +1,5 @@
 class WordsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_word, only: [:show, :destroy, :edit, :update]
 
   def index


### PR DESCRIPTION
# WHAT

- 単語登録機能の操作をログインユーザーのみに許可
- 左上のアイコンの遷移先をログイン時と非ログイン時で変更