### PR TITLE
特定の文字列をリンクに置換えて表示させる

### DIFF
--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -2,8 +2,6 @@ class WordsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_word, only: [:show, :destroy, :edit, :update]
 
-
-  
   def index
     @words = current_user.words.order(created_at: :desc).page(params[:page]).per(24)
   end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -2,6 +2,8 @@ class WordsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_word, only: [:show, :destroy, :edit, :update]
 
+
+  
   def index
     @words = current_user.words.order(created_at: :desc).page(params[:page]).per(24)
   end
@@ -12,6 +14,7 @@ class WordsController < ApplicationController
 
   def create
     @word = current_user.words.new(words_params)
+    @word.content_replace = text_conversion(words_params[:content])
     if @word.save
       redirect_to words_path, notice: '単語を登録しました！'
     else
@@ -39,6 +42,14 @@ class WordsController < ApplicationController
   end
 
   private
+
+  def text_conversion(content_text)
+    content_text.gsub(/\[.+\]\(http.+\)/) do |text|
+      url_title = text.slice(/\[.+\]/).delete('[').delete(']')
+      url_address = text.slice(/\(http.+\)/).delete('(').delete(')')
+      "<a href=\"#{url_address}\" target=\"_blank\">#{url_title}</a>"
+    end
+  end
 
   def words_params
       params.require(:word).permit(:word, :kana, :content)

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -12,7 +12,7 @@ class WordsController < ApplicationController
 
   def create
     @word = current_user.words.new(words_params)
-    @word.content_replace = text_conversion(words_params[:content])
+    @word.content_replace = Word.text_conversion(words_params[:content])
     if @word.save
       redirect_to words_path, notice: '単語を登録しました！'
     else
@@ -41,14 +41,6 @@ class WordsController < ApplicationController
 
   private
 
-  def text_conversion(content_text)
-    content_text.gsub(/\[.+\]\(http.+\)/) do |text|
-      url_title = text.slice(/\[.+\]/).delete('[').delete(']')
-      url_address = text.slice(/\(http.+\)/).delete('(').delete(')')
-      "<a href=\"#{url_address}\" target=\"_blank\">#{url_title}</a>"
-    end
-  end
-
   def words_params
       params.require(:word).permit(:word, :kana, :content)
   end
@@ -56,4 +48,5 @@ class WordsController < ApplicationController
   def set_word
     @word = current_user.words.find_by(id: params[:id])
   end
+  
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -4,4 +4,13 @@ class Word < ApplicationRecord
   validates :kana, presence: true
   validates :content, presence: true
   validates :content_replace, presence: true
+
+  def self.text_conversion(content_text)
+    content_text.gsub(/\[.+\]\(http.+\)/) do |text|
+      url_title = text.slice(/\[.+\]/).delete('[').delete(']')
+      url_address = text.slice(/\(http.+\)/).delete('(').delete(')')
+      "<a href=\"#{url_address}\" target=\"_blank\">#{url_title}</a>"
+    end
+  end
+  
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -3,4 +3,5 @@ class Word < ApplicationRecord
   validates :word, presence: true
   validates :kana, presence: true
   validates :content, presence: true
+  validates :content_replace, presence: true
 end

--- a/app/views/words/show.html.erb
+++ b/app/views/words/show.html.erb
@@ -20,7 +20,7 @@
       </div>
       <!-- content area -->
       <div class="wordshow_content">
-        <%= @word.content %>
+        <%= simple_format(@word.content) %>
       </div>
       <div class="mt-5">
         <%= link_to 'back', :back %>

--- a/app/views/words/show.html.erb
+++ b/app/views/words/show.html.erb
@@ -20,7 +20,7 @@
       </div>
       <!-- content area -->
       <div class="wordshow_content">
-        <%= simple_format(@word.content) %>
+        <%= simple_format(@word.content_replace) %>
       </div>
       <div class="mt-5">
         <%= link_to 'back', :back %>

--- a/app/views/words/show.html.erb
+++ b/app/views/words/show.html.erb
@@ -20,7 +20,7 @@
       </div>
       <!-- content area -->
       <div class="wordshow_content">
-        <%= simple_format(@word.content_replace) %>
+        <%= simple_format(sanitize(@word.content_replace, attributes: %w(href target)), {}, sanitize: false) %>
       </div>
       <div class="mt-5">
         <%= link_to 'back', :back %>


### PR DESCRIPTION
# WHAT

- [x] 投稿データがビューで改行を反映させて表示できるようにする
    - simple_formatで改行反映
- [x] []と()を用いた文字列を<a></a>タグに置換えてcontent_replaceカラムに保存
    - gbubを使って投稿されたデータをHTMLに置換
- [x] 変換したものをビューで表示
    - sanitizeを使用してsimple_fomatでtargetが削除されてしまう問題を解決